### PR TITLE
Resource Mover MSI Access

### DIFF
--- a/CopyKeys/CopyKeys.ps1
+++ b/CopyKeys/CopyKeys.ps1
@@ -15,11 +15,15 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $false,
-               HelpMessage="Location of the output file.")]
+    [Parameter(
+        Mandatory = $false,
+        HelpMessage="Switch parameter indicating if the MSI created by Azure Resource Mover" + `
+            "for moving the selected VM resources need to be given access to the target " + `
+            "BEK/KEK key vaults.")]
     [switch]$AllowResourceMoverAccess = $false,
-    [Parameter(Mandatory = $false,
-               HelpMessage="Location of the output file.")]
+    [Parameter(
+        Mandatory = $false,
+        HelpMessage="Location of the output file.")]
     [string]$FilePath = $null)
 
 ### Checking for module versions and assemblies.
@@ -319,7 +323,6 @@ class ConstantStrings
     static [string] $loadingBEK = "Loading target BEK vault"
     static [string] $loadingKEK = "Loading target KEK vault"
     static [string] $loadingRG = "Loading resource groups"
-    static [string] $managementAzureEndpoint = "https://management.azure.com"
     static [string] $moveResourceType = "moveresources"
     static [string] $newPrefix = "(new)"
     static [string] $noAdeVmInResourceGroup = "Selected resource group does `nnot contain any " + `
@@ -1242,7 +1245,9 @@ function Get-UrlString([string] $apiVersion, [string[]]$tokens)
         throw [Errors]::UrlTokensMissing()
     }
 
-    $url = [ConstantStrings]::managementAzureEndpoint + '/'
+    $context = Get-AzContext
+
+    $url = ($context.Environment.ResourceManagerUrl).TrimEnd('/') + '/'
     $url += $tokens.Trim('/') -Join '/'
     $url = $url.Trim('/')
     $url += '?' + [ConstantStrings]::apiVersion + '=' + $apiVersion

--- a/CopyKeys/README.md
+++ b/CopyKeys/README.md
@@ -5,6 +5,7 @@ This script copies the disk encryption keys and key encryption keys for Azure Di
 ## parameters
 
 - name="**_FilePath_**" - **Optional** parameter defining the location of the output file.
+- name="**_AllowResourceMoverAccess_**" - **Optional** switch parameter indicating if the MSI created by Azure Resource Mover for moving the selected VM resources need to be given access to the target BEK/KEK key vaults.
 
 ## updates
 
@@ -13,3 +14,4 @@ This script copies the disk encryption keys and key encryption keys for Azure Di
 |01/21 | - Improved Authentication mechanism with Get-AzAccessToken.</br> - Removed dependence on deprecated key vault properties.</br> - Improved logging. |
 |02/23 | - Fixed GUI issues in case of varying resolution.</br> - Fixed login bug in case of expired context. |
 |02/28 | - Removing hardcoded vault endpoint and replacing it with one provided by KeyVault RP. |
+|04/09 | - Providing MoveCollection MSI with appropriate target key vault access in case the script is used for Azure Resource Mover. |


### PR DESCRIPTION
Adding changes to provide MoveCollection MSI with required target key vault key and secret permissions. This is only done if the script is used with the new switch parameter. The move collection details are gathered by checking the resource links associated with the selected VMs.